### PR TITLE
Suport for CLOUDINARY_URL from ENV

### DIFF
--- a/autoform-cloudinary-server.js
+++ b/autoform-cloudinary-server.js
@@ -12,8 +12,22 @@ Meteor.methods({
       api_key: apiKey(),
       api_secret: apiSecret()
     });
+  },
+  publicCredentials: function() {
+    if (cloudinaryURL) {
+      return {
+        cloudName: apiHost(),
+        apiKey: apiKey()
+      }
+    }
   }
 });
+
+apiHost = function() {
+  if (cloudinaryURL) {
+    return cloudinaryURL.hostname();
+  }
+};
 
 apiKey = function () {
   if (cloudinaryURL) {

--- a/autoform-cloudinary-server.js
+++ b/autoform-cloudinary-server.js
@@ -1,4 +1,5 @@
 var cloudinary = Npm.require('cloudinary');
+var cloudinaryURL = new URI(process.env.CLOUDINARY_URL);
 
 Meteor.methods({
   afCloudinarySign: function (params) {
@@ -15,6 +16,10 @@ Meteor.methods({
 });
 
 apiKey = function () {
+  if (cloudinaryURL) {
+    return cloudinaryURL.username();
+  }
+
   if (! Meteor.settings ||
       ! Meteor.settings.public ||
       ! Meteor.settings.public.CLOUDINARY_API_KEY) {
@@ -25,6 +30,10 @@ apiKey = function () {
 };
 
 apiSecret = function () {
+  if (cloudinaryURL) {
+    return cloudinaryURL.password();
+  }
+
   if (! Meteor.settings ||
       ! Meteor.settings.CLOUDINARY_API_SECRET) {
     throw new Error('Meteor.settings.CLOUDINARY_API_SECRET is undefined');

--- a/autoform-cloudinary-server.js
+++ b/autoform-cloudinary-server.js
@@ -1,5 +1,8 @@
 var cloudinary = Npm.require('cloudinary');
-var cloudinaryURL = new URI(process.env.CLOUDINARY_URL);
+
+if (process.env.CLOUDINARY_URL) {
+  var cloudinaryURL = new URI(process.env.CLOUDINARY_URL);
+}
 
 Meteor.methods({
   afCloudinarySign: function (params) {

--- a/autoform-cloudinary.js
+++ b/autoform-cloudinary.js
@@ -7,23 +7,19 @@ AutoForm.addInputType('cloudinary', {
 });
 
 Meteor.startup(function () {
-  var cloudinaryURL = new URI(process.env.CLOUDINARY_URL);
-
-  if (cloudinaryURL) {
     Meteor.call('publicCredentials', function(err, res) {
-      if (!err) {
+      if (res) {
         $.cloudinary.config({
           cloud_name: res.cloudName,
           api_key: res.apiKey
         });
+      } else {
+        $.cloudinary.config({
+          cloud_name: Meteor.settings.public.CLOUDINARY_CLOUD_NAME,
+          api_key: Meteor.settings.public.CLOUDINARY_API_KEY
+        });
       }
     });
-  } else {
-    $.cloudinary.config({
-      cloud_name: cloudinaryURL.hostname(),
-      api_key: cloudinaryURL.username()
-    });
-  }
 });
 
 var templates = ['afCloudinary', 'afCloudinary_bootstrap3'];

--- a/autoform-cloudinary.js
+++ b/autoform-cloudinary.js
@@ -7,10 +7,19 @@ AutoForm.addInputType('cloudinary', {
 });
 
 Meteor.startup(function () {
-  $.cloudinary.config({
-    cloud_name: Meteor.settings.public.CLOUDINARY_CLOUD_NAME,
-    api_key: Meteor.settings.public.CLOUDINARY_API_KEY
-  });
+  var cloudinaryURL = new URI(process.env.CLOUDINARY_URL);
+
+  if (cloudinaryURL) {
+    $.cloudinary.config({
+      cloud_name: Meteor.settings.public.CLOUDINARY_CLOUD_NAME,
+      api_key: Meteor.settings.public.CLOUDINARY_API_KEY
+    });
+  } else {
+    $.cloudinary.config({
+      cloud_name: cloudinaryURL.hostname(),
+      api_key: cloudinaryURL.username()
+    });
+  }
 });
 
 var templates = ['afCloudinary', 'afCloudinary_bootstrap3'];

--- a/autoform-cloudinary.js
+++ b/autoform-cloudinary.js
@@ -10,9 +10,13 @@ Meteor.startup(function () {
   var cloudinaryURL = new URI(process.env.CLOUDINARY_URL);
 
   if (cloudinaryURL) {
-    $.cloudinary.config({
-      cloud_name: Meteor.settings.public.CLOUDINARY_CLOUD_NAME,
-      api_key: Meteor.settings.public.CLOUDINARY_API_KEY
+    Meteor.call('publicCredentials', function(err, res) {
+      if (!err) {
+        $.cloudinary.config({
+          cloud_name: res.cloudName,
+          api_key: res.apiKey
+        });
+      }
     });
   } else {
     $.cloudinary.config({


### PR DESCRIPTION
I've added the option to use `process.env.CLOUDINARY_URL` and parse the relevant credentials. This makes is easier to deploy using Heroku or similar where a `.env` file is used instead of `settings.json`

Fallback behaviour should be the same so this only has an effect for anyone wishing to use `process.env.CLOUDINARY_URL`
### Changes
- publicCredentials method to expose `cloudName` and `apiKey` to client since process.env is not available on the client. 
- updated apiKey and apiSecret functions to find credentials from `CLOUDINARY_URL` if set.
- client config now uses response from publicCredentials function if available. 
